### PR TITLE
chore: update daedalus terms links

### DIFF
--- a/src/resources/footer/daedalus.js
+++ b/src/resources/footer/daedalus.js
@@ -9,7 +9,7 @@ _Past performance is not indicative of future results. Any investment in blockch
     `,
     terms_of_service: {
       label: 'Terms of service',
-      href: 'https://static.iohk.io/terms/iohktermsandconditions.pdf'
+      href: 'https://static.iohk.io/terms/iog-terms-and-conditions.pdf'
     },
     data_protection: {
       label: 'Data Protection',
@@ -68,7 +68,7 @@ Cardanoはソフトウェアプラットフォームのみを提供します。�
     `,
     terms_of_service: {
       label: '利用規約',
-      href: 'https://static.iohk.io/terms/iohktermsandconditions.pdf'
+      href: 'https://static.iohk.io/terms/iog-terms-and-conditions.pdf'
     },
     data_protection: {
       label: 'データ保護',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update the terms and conditions links to keep filenames consistent across all sites. The content is the same on both files.


* **What is the current behavior?** (You can also link to an open issue here)
Terms of service link on Daedalus footer points to https://static.iohk.io/terms/iohktermsandconditions.pdf


* **What is the new behavior (if this is a feature change)?**
Terms of service link on Daedalus footer points to https://static.iohk.io/terms/iog-terms-and-conditions.pdf


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No